### PR TITLE
Fixed player input on must hit sections

### DIFF
--- a/FNFBot/Program.cs
+++ b/FNFBot/Program.cs
@@ -82,7 +82,9 @@ namespace FNFBot
                             if (sect.MustHitSection)
                             {
                                 foreach (FNFSong.FNFNote n in sect.Notes)
-                                    notesToPlay.Add(n);
+                                    bool flag = (decimal) n.Type >= 4;
+                                    if (!flag)
+                                        notesToPlay.Add(n);
                             }
                             else
                             {

--- a/FNFBot/Program.cs
+++ b/FNFBot/Program.cs
@@ -82,9 +82,11 @@ namespace FNFBot
                             if (sect.MustHitSection)
                             {
                                 foreach (FNFSong.FNFNote n in sect.Notes)
-                                    bool flag = (decimal) n.Type >= 4;
-                                    if (!flag)
+                                {
+                                    if ((int)n.Type >= 4)
+                                        continue;
                                         notesToPlay.Add(n);
+                                }
                             }
                             else
                             {


### PR DESCRIPTION
Before this, the bot would press every arrow inside must hit sections, including the enemy's notes, this should probably fix it.
This is a fix to one of my issues sent to the repo, which worked (at least with the monster chart and stuff like that).